### PR TITLE
Add seo-automation-engine link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Inspired by [@agamm](https://github.com/agamm/awesome-developer-first) and [@mmc
 * [learn-from-open-source](https://github.com/elie222/learn-from-open-source) ![open-source](https://img.shields.io/badge/open--source-black) 
 * [openapi-tools](https://github.com/apisyouwonthate/openapi.tools)
 * [usage-based-pricing](https://github.com/appsmithorg/usage-based-pricing)
+* [seo-automation-engine](https://github.com/abusufyan-netizen/seo-automation-engine)
 
 ### collections
 


### PR DESCRIPTION
Hello! I would like to contribute a new resource to the GitHub Repositories section. 

The SEO Automation Engine is an open-source, dependency-free crawling loop and competitive gap analyzer. It runs entirely on the standard library layout (blank requirements file) and handles adaptive hybrid processing through local execution modules (Ollama) or secure cloud infrastructure (Gemini API tokens).

URL: https://github.com/abusufyan-netizen/seo-automation-engine